### PR TITLE
fix: add name to jobs for try to force validate pr before merging

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-and-test:
+    name: CI Build & Test
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
test to add a name job for lock merging without validate test on PR